### PR TITLE
Add basic admin auth for signup/unregister

### DIFF
--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+[
+  {
+    "username": "teacher1",
+    "password": "changeme"
+  }
+]


### PR DESCRIPTION
This PR adds a simple teacher authentication prototype using HTTP Basic auth and a short-term `teachers.json` to restrict register/unregister endpoints to teachers as requested in issue #5 (Admin Mode).